### PR TITLE
Update workflow to publish chart to GitHub OCI registry

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   publish-ghcr:
-    if: github.repository_owner == 'onosproject'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Intel Corporation
+
+name: Publish Umbrella Helm Chart
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'aether-roc-umbrella/Chart.yaml'
+
+jobs:
+  publish-ghcr:
+    if: github.repository_owner == 'onosproject'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Build chart dependencies
+        run: |
+          helm dep build aether-roc-umbrella
+
+      - name: Package Helm chart
+        run: |
+          helm package aether-roc-umbrella
+
+      - name: Login to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push chart to GHCR
+        run: |
+          # Convert owner name to lowercase for the registry URL
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          helm push aether-roc-umbrella-*.tgz oci://ghcr.io/$OWNER
+
+      - name: Logout from GHCR
+        if: always()
+        run: |
+          helm registry logout ghcr.io

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 Intel Corporation
 
-name: Tag/Publish Release
+name: Version Management
 
 on:
   push:
@@ -12,16 +12,6 @@ jobs:
   # CAUTION: Other actions depend on this name "tag-github"
   tag-github:
     uses: onosproject/.github/.github/workflows/tag-github.yml@main
-    secrets: inherit
-
-  publish:
-    needs: tag-github
-    if: github.repository_owner == 'onosproject'
-    uses: onosproject/.github/.github/workflows/helm-publish-umbrella.yml@main
-    with:
-      umbrella_charts: ./aether-roc-umbrella
-      remote_host: static.opennetworking.org
-      remote_path: /srv/sites/charts.aetherproject.org/
     secrets: inherit
 
   update-version:


### PR DESCRIPTION
Publishes the aether-roc-umbrella chart to GitHub Package's OCI registry.  The other charts in the repo are not published as they are seemingly not consumed independently of the umbrella chart.