### PR TITLE
Pull Docker images from GHCR registry by default

### DIFF
--- a/aether-mock-exporter/Chart.yaml
+++ b/aether-mock-exporter/Chart.yaml
@@ -8,7 +8,7 @@ name: aether-mock-exporter
 description: Aether ROC Mock Exporter
 kubeVersion: ">=1.15.0"
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: v0.0.0
 keywords:
   - aether

--- a/aether-mock-exporter/Chart.yaml
+++ b/aether-mock-exporter/Chart.yaml
@@ -8,8 +8,8 @@ name: aether-mock-exporter
 description: Aether ROC Mock Exporter
 kubeVersion: ">=1.15.0"
 type: application
-version: 0.2.2
-appVersion: v0.4.1
+version: 0.2.3
+appVersion: v0.4.2
 keywords:
   - aether
   - exporter

--- a/aether-mock-exporter/Chart.yaml
+++ b/aether-mock-exporter/Chart.yaml
@@ -9,7 +9,7 @@ description: Aether ROC Mock Exporter
 kubeVersion: ">=1.15.0"
 type: application
 version: 0.2.2
-appVersion: v0.0.0
+appVersion: v0.4.1
 keywords:
   - aether
   - exporter

--- a/aether-mock-exporter/templates/_helpers.tpl
+++ b/aether-mock-exporter/templates/_helpers.tpl
@@ -54,3 +54,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "demo-exporter.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+aether-mock-exporter image name
+*/}}
+{{- define "aether-mock-exporter.imagename" -}}
+{{- if .Values.global.image.registry -}}
+{{- printf "%s/" .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s/" .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- tpl .Values.image.tag . -}}
+{{- end -}}
+{{- end -}}

--- a/aether-mock-exporter/templates/deployment.yaml
+++ b/aether-mock-exporter/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "aether-mock-exporter.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: POD_NAMESPACE

--- a/aether-mock-exporter/values.yaml
+++ b/aether-mock-exporter/values.yaml
@@ -17,7 +17,7 @@ global:
 image:
   registry: ""
   repository: onosproject/aether-mock-exporter
-  tag: v0.4.1
+  tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/aether-mock-exporter/values.yaml
+++ b/aether-mock-exporter/values.yaml
@@ -9,7 +9,13 @@ fullnameOverride: "aether-mock-exporter"
 replicaCount: 1
 annotations: {}
 
+global:
+  image:
+    registry: ""
+    tag: ""
+
 image:
+  registry: ""
   repository: onosproject/aether-mock-exporter
   tag: v0.4.1
   pullPolicy: IfNotPresent

--- a/aether-roc-api/Chart.yaml
+++ b/aether-roc-api/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-api
 description: Aether ROC API
 kubeVersion: ">=1.15.0"
 type: application
-version: 1.7.14
+version: 1.7.15
 appVersion: v0.10.26
 keywords:
   - aether

--- a/aether-roc-api/Chart.yaml
+++ b/aether-roc-api/Chart.yaml
@@ -8,7 +8,7 @@ description: Aether ROC API
 kubeVersion: ">=1.15.0"
 type: application
 version: 1.7.15
-appVersion: v0.10.26
+appVersion: v0.10.30
 keywords:
   - aether
   - config

--- a/aether-roc-api/templates/_helpers.tpl
+++ b/aether-roc-api/templates/_helpers.tpl
@@ -53,3 +53,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "aether-roc-api.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+aether-roc-api image name
+*/}}
+{{- define "aether-roc-api.imagename" -}}
+{{- if .Values.global.image.registry -}}
+{{- printf "%s/" .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s/" .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- tpl .Values.image.tag . -}}
+{{- end -}}
+{{- end -}}

--- a/aether-roc-api/templates/deployment.yaml
+++ b/aether-roc-api/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
+          image: {{ include "aether-roc-api.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: NAMESPACE

--- a/aether-roc-api/values.yaml
+++ b/aether-roc-api/values.yaml
@@ -8,7 +8,13 @@
 
 replicaCount: 1
 
+global:
+  image:
+    registry: ""
+    tag: ""
+
 image:
+  registry: ""
   repository: onosproject/aether-roc-api
   tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent

--- a/aether-roc-gui/Chart.yaml
+++ b/aether-roc-gui/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-gui
 description: Aether ROC Graphical User Interface
 kubeVersion: ">=1.15.0"
 type: application
-version: 2.1.20
+version: 2.1.21
 appVersion: v0.10.3
 keywords:
   - aether

--- a/aether-roc-gui/Chart.yaml
+++ b/aether-roc-gui/Chart.yaml
@@ -8,7 +8,7 @@ description: Aether ROC Graphical User Interface
 kubeVersion: ">=1.15.0"
 type: application
 version: 2.1.21
-appVersion: v0.10.3
+appVersion: v0.10.4
 keywords:
   - aether
   - roc

--- a/aether-roc-gui/templates/_helpers.tpl
+++ b/aether-roc-gui/templates/_helpers.tpl
@@ -55,6 +55,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
+aether-roc-gui image name
+*/}}
+{{- define "aether-roc-gui.imagename" -}}
+{{- if .Values.global.image.registry -}}
+{{- printf "%s/" .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s/" .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- tpl .Values.image.tag . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "aether-roc-gui.serviceAccountName" -}}

--- a/aether-roc-gui/templates/deployment.yaml
+++ b/aether-roc-gui/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
+          image: {{ include "aether-roc-gui.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: NAMESPACE

--- a/aether-roc-gui/values.yaml
+++ b/aether-roc-gui/values.yaml
@@ -8,7 +8,13 @@
 
 replicaCount: 1
 
+global:
+  image:
+    registry: ""
+    tag: ""
+
 image:
+  registry: ""
   repository: onosproject/aether-roc-gui
   tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent

--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -21,15 +21,15 @@ dependencies:
   - name: onos-topo
     condition: import.onos-topo.enabled
     repository: oci://ghcr.io/onosproject/charts
-    version: 1.5.0
+    version: 1.5.3
   - name: onos-config
     condition: import.onos-config.enabled
     repository: oci://ghcr.io/onosproject/charts
-    version: 1.8.12
+    version: 1.8.14
   - name: onos-cli
     condition: import.onos-cli.enabled
     repository: oci://ghcr.io/onosproject/charts
-    version: 1.3.15
+    version: 1.3.19
   - name: aether-roc-api
     condition: import.aether-roc-api.enabled
     repository: "file://../aether-roc-api"

--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -8,7 +8,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 2.1.39
+version: 2.1.40
 appVersion: v0.0.0
 keywords:
   - aether
@@ -33,7 +33,7 @@ dependencies:
   - name: aether-roc-api
     condition: import.aether-roc-api.enabled
     repository: "file://../aether-roc-api"
-    version: 1.7.14
+    version: 1.7.15
   - name: aether-roc-gui-v2
     condition: import.aether-roc-gui.v2-0.enabled
     repository: oci://ghcr.io/onosproject/charts
@@ -41,7 +41,7 @@ dependencies:
   - name: aether-roc-gui
     condition: import.aether-roc-gui.v2-1.enabled
     repository: "file://../aether-roc-gui"
-    version: 2.1.20
+    version: 2.1.21
     alias: aether-roc-gui-v2-1
   - name: sdcore-adapter-v2
     condition: import.sdcore-adapter.v2-0.enabled
@@ -51,17 +51,17 @@ dependencies:
   - name: sdcore-prom-kafka
     condition: import.sdcore-prom-kafka.enabled
     repository: "file://../sdcore-prom-kafka"
-    version: 1.0.0
+    version: 1.0.1
     alias: sdcore-prom-kafka
   - name: sdcore-adapter
     condition: import.sdcore-adapter.v2-1.enabled
     repository: "file://../sdcore-adapter"
-    version: 2.1.5
+    version: 2.1.6
     alias: sdcore-adapter-v2-1
   - name: subscriber-proxy
     condition: import.subscriber-proxy.enabled
     repository: "file://../subscriber-proxy"
-    version: 0.2.1
+    version: 0.2.2
   - name: nginx
     alias: sdcore-test-dummy
     condition: import.sdcore-test-dummy.enabled
@@ -89,14 +89,14 @@ dependencies:
   - name: prom-label-proxy
     condition: import.prom-label-proxy.amp.enabled
     repository: "file://../prom-label-proxy"
-    version: 0.1.3
+    version: 0.1.4
     alias: prom-label-proxy-amp
   - name: prom-label-proxy
     condition: import.prom-label-proxy.acc.enabled
     repository: "file://../prom-label-proxy"
-    version: 0.1.3
+    version: 0.1.4
     alias: prom-label-proxy-acc
   - name: aether-mock-exporter
     condition: import.aether-mock-exporter.enabled
     repository: "file://../aether-mock-exporter"
-    version: 0.2.1
+    version: 0.2.2

--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -99,4 +99,4 @@ dependencies:
   - name: aether-mock-exporter
     condition: import.aether-mock-exporter.enabled
     repository: "file://../aether-mock-exporter"
-    version: 0.2.2
+    version: 0.2.3

--- a/aether-roc-umbrella/values.yaml
+++ b/aether-roc-umbrella/values.yaml
@@ -11,7 +11,7 @@ global:
   fullnameOverride: "onos"
   nameOverride: ""
   image:
-    registry: ""
+    registry: "ghcr.io"  # Use ghcr.io for all images
     tag: ""
   atomix:
     store:

--- a/network-diag-app/Chart.yaml
+++ b/network-diag-app/Chart.yaml
@@ -5,4 +5,4 @@
 apiVersion: v2
 appVersion: 0.0.4-dev
 name: network-diag-app
-version: 0.1.0
+version: 0.1.1

--- a/network-diag-app/Chart.yaml
+++ b/network-diag-app/Chart.yaml
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2
-appVersion: 0.0.4-dev
+appVersion: master
 name: network-diag-app
 version: 0.1.1

--- a/network-diag-app/templates/_helpers.tpl
+++ b/network-diag-app/templates/_helpers.tpl
@@ -57,3 +57,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "network-test.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+network-diag-app image name
+*/}}
+{{- define "network-diag-app.imagename" -}}
+{{- if .Values.global.image.registry -}}
+{{- printf "%s/" .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s/" .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- tpl .Values.image.tag . -}}
+{{- end -}}
+{{- end -}}

--- a/network-diag-app/templates/deployment.yaml
+++ b/network-diag-app/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "network-diag-app.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: public

--- a/network-diag-app/values.yaml
+++ b/network-diag-app/values.yaml
@@ -11,7 +11,7 @@ image:
   registry: "registry.aetherproject.org"
   repository: aether-apps/network-diag-app
   pullPolicy: Always
-  tag: master
+  tag: "{{ .Chart.AppVersion }}"
 
 service:
   name: network-diag-app

--- a/network-diag-app/values.yaml
+++ b/network-diag-app/values.yaml
@@ -2,8 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+global:
+  image:
+    registry: ""
+    tag: ""
+
 image:
-  repository: registry.aetherproject.org/aether-apps/network-diag-app
+  registry: "registry.aetherproject.org"
+  repository: aether-apps/network-diag-app
   pullPolicy: Always
   tag: master
 

--- a/prom-label-proxy/Chart.yaml
+++ b/prom-label-proxy/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: prom-label-proxy
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: v0.3.6
 description: Prom Label Proxy
 keywords:

--- a/prom-label-proxy/templates/_helpers.tpl
+++ b/prom-label-proxy/templates/_helpers.tpl
@@ -54,3 +54,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "prom-label-proxy.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+prom-label-proxy image name
+*/}}
+{{- define "prom-label-proxy.imagename" -}}
+{{- if .Values.global.image.registry -}}
+{{- printf "%s/" .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s/" .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- tpl .Values.image.tag . -}}
+{{- end -}}
+{{- end -}}

--- a/prom-label-proxy/templates/deployment.yaml
+++ b/prom-label-proxy/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "prom-label-proxy.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: POD_NAMESPACE

--- a/prom-label-proxy/values.yaml
+++ b/prom-label-proxy/values.yaml
@@ -7,7 +7,13 @@ fullnameOverride: ""
 replicaCount: 1
 annotations: {}
 
+global:
+  image:
+    registry: ""
+    tag: ""
+
 image:
+  registry: ""
   repository: onosproject/prom-label-proxy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/prom-label-proxy/values.yaml
+++ b/prom-label-proxy/values.yaml
@@ -17,7 +17,7 @@ image:
   repository: onosproject/prom-label-proxy
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.3.6
+  tag: "{{ .Chart.AppVersion }}"
   pullSecrets: []
 
 resources:

--- a/sdcore-adapter/Chart.yaml
+++ b/sdcore-adapter/Chart.yaml
@@ -8,7 +8,7 @@ name: sdcore-adapter
 kubeVersion: ">=1.17.0"
 type: application
 version: 2.1.6
-appVersion: v2.1.0
+appVersion: v0.4.9
 description: Aether SD-Core Adapter
 keywords:
   - aether

--- a/sdcore-adapter/Chart.yaml
+++ b/sdcore-adapter/Chart.yaml
@@ -7,7 +7,7 @@ apiVersion: v2
 name: sdcore-adapter
 kubeVersion: ">=1.17.0"
 type: application
-version: 2.1.5
+version: 2.1.6
 appVersion: v2.1.0
 description: Aether SD-Core Adapter
 keywords:

--- a/sdcore-adapter/templates/_helpers.tpl
+++ b/sdcore-adapter/templates/_helpers.tpl
@@ -54,3 +54,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "sdcore-adapter.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+sdcore-adapter image name
+*/}}
+{{- define "sdcore-adapter.imagename" -}}
+{{- if .Values.global.image.registry -}}
+{{- printf "%s/" .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s/" .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- tpl .Values.image.tag . -}}
+{{- end -}}
+{{- end -}}

--- a/sdcore-adapter/templates/deployment.yaml
+++ b/sdcore-adapter/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "sdcore-adapter.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: POD_NAMESPACE

--- a/sdcore-adapter/values.yaml
+++ b/sdcore-adapter/values.yaml
@@ -17,7 +17,7 @@ global:
 image:
   registry: ""
   repository: onosproject/sdcore-adapter
-  tag: v0.4.7
+  tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/sdcore-adapter/values.yaml
+++ b/sdcore-adapter/values.yaml
@@ -9,7 +9,13 @@ fullnameOverride: ""
 replicaCount: 1
 annotations: {}
 
+global:
+  image:
+    registry: ""
+    tag: ""
+
 image:
+  registry: ""
   repository: onosproject/sdcore-adapter
   tag: v0.4.7
   pullPolicy: IfNotPresent

--- a/sdcore-prom-kafka/Chart.yaml
+++ b/sdcore-prom-kafka/Chart.yaml
@@ -8,7 +8,7 @@ name: sdcore-prom-kafka
 kubeVersion: ">=1.17.0"
 type: application
 version: 1.0.1
-appVersion: v2.1.0
+appVersion: v0.4.9
 description: Poll Prometheus for core changes and push to Kafka
 keywords:
   - aether

--- a/sdcore-prom-kafka/Chart.yaml
+++ b/sdcore-prom-kafka/Chart.yaml
@@ -7,7 +7,7 @@ apiVersion: v2
 name: sdcore-prom-kafka
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: v2.1.0
 description: Poll Prometheus for core changes and push to Kafka
 keywords:

--- a/sdcore-prom-kafka/templates/_helpers.tpl
+++ b/sdcore-prom-kafka/templates/_helpers.tpl
@@ -55,3 +55,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "sdcore-prom-kafka.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+sdcore-prom-kafka image name
+*/}}
+{{- define "sdcore-prom-kafka.imagename" -}}
+{{- if .Values.global.image.registry -}}
+{{- printf "%s/" .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s/" .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- tpl .Values.image.tag . -}}
+{{- end -}}
+{{- end -}}

--- a/sdcore-prom-kafka/templates/deployment.yaml
+++ b/sdcore-prom-kafka/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "sdcore-prom-kafka.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: POD_NAMESPACE

--- a/sdcore-prom-kafka/values.yaml
+++ b/sdcore-prom-kafka/values.yaml
@@ -9,7 +9,13 @@ fullnameOverride: ""
 replicaCount: 1
 annotations: {}
 
+global:
+  image:
+    registry: ""
+    tag: ""
+
 image:
+  registry: ""
   repository: onosproject/sdcore-adapter
   tag: v0.4.4
   pullPolicy: IfNotPresent

--- a/sdcore-prom-kafka/values.yaml
+++ b/sdcore-prom-kafka/values.yaml
@@ -17,7 +17,7 @@ global:
 image:
   registry: ""
   repository: onosproject/sdcore-adapter
-  tag: v0.4.4
+  tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/subscriber-proxy/Chart.yaml
+++ b/subscriber-proxy/Chart.yaml
@@ -6,7 +6,7 @@ apiVersion: v2
 name: subscriber-proxy
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: v0.3.2
 description: Subscriber-Proxy
 keywords:

--- a/subscriber-proxy/templates/_helpers.tpl
+++ b/subscriber-proxy/templates/_helpers.tpl
@@ -56,6 +56,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
+subscriber-proxy image name
+*/}}
+{{- define "subscriber-proxy.imagename" -}}
+{{- if .Values.global.image.registry -}}
+{{- printf "%s/" .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s/" .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- tpl .Values.image.tag . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "aether-roc-gui.serviceAccountName" -}}

--- a/subscriber-proxy/templates/deployment.yaml
+++ b/subscriber-proxy/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "subscriber-proxy.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: POD_NAMESPACE

--- a/subscriber-proxy/values.yaml
+++ b/subscriber-proxy/values.yaml
@@ -16,7 +16,7 @@ global:
 image:
   registry: ""
   repository: onosproject/subscriber-proxy
-  tag: v0.3.2
+  tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/subscriber-proxy/values.yaml
+++ b/subscriber-proxy/values.yaml
@@ -8,7 +8,13 @@ fullnameOverride: ""
 replicaCount: 1
 annotations: {}
 
+global:
+  image:
+    registry: ""
+    tag: ""
+
 image:
+  registry: ""
   repository: onosproject/subscriber-proxy
   tag: v0.3.2
   pullPolicy: IfNotPresent


### PR DESCRIPTION
This PR:
* adopts the image naming convention from the ONOS Helm charts, which supports a `global` image registry override
* updates the chart versions to those with Docker images in GHCR
* sets the global registry override to `ghcr.io`

The chart was tested with the Quickstart AMP workflow [here](https://github.com/andybavier/aether-onramp/actions/runs/22240061939/job/64586829369).  The test verified that all the relevant images were pulled from GHCR.

 